### PR TITLE
feat: add summarizer pipeline skeleton

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,61 @@
+name: manual-run
+
+on:
+  workflow_dispatch:
+    inputs:
+      audio_url:
+        description: "Audio URL"
+        required: true
+      title:
+        description: "Episode Title"
+        required: true
+      date:
+        description: "Recorded Date (YYYY-MM-DD)"
+        required: true
+      basename:
+        description: "Output Basename"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Write settings.yaml
+        run: |
+          mkdir -p config
+          cat <<'YAML' > config/settings.yaml
+          episode:
+            audio_url: "${{ github.event.inputs.audio_url }}"
+            title: "${{ github.event.inputs.title }}"
+            date: "${{ github.event.inputs.date }}"
+          output:
+            dir: "data/output"
+            basename: "${{ github.event.inputs.basename }}"
+          transcribe:
+            model_size: "base"
+            language: "ja"
+            beam_size: 5
+            vad_frame_ms: 30
+            vad_aggressiveness: 2
+          YAML
+      - run: python -m src.are_summarizer.cli --config config/settings.yaml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: outputs-${{ github.event.inputs.basename }}
+          path: data/output/
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: add outputs for ${{ github.event.inputs.basename }}"
+          file_pattern: data/output/*.srt data/output/*.txt data/output/*_summary.md

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,68 @@
+name: weekly-run
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install FFmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Write settings.yaml
+        run: |
+          mkdir -p config
+          cat <<'YAML' > config/settings.yaml
+          episode:
+            audio_url: "${{ vars.AUDIO_URL }}"
+            title: "${{ vars.EPISODE_TITLE }}"
+            date: "${{ vars.EPISODE_DATE }}"
+          output:
+            dir: "data/output"
+            basename: "${{ vars.OUTPUT_BASENAME }}"
+          transcribe:
+            model_size: "base"
+            language: "ja"
+            beam_size: 5
+            vad_frame_ms: 30
+            vad_aggressiveness: 2
+          YAML
+
+      - name: Run pipeline
+        run: |
+          python -m src.are_summarizer.cli --config config/settings.yaml
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: outputs-${{ vars.OUTPUT_BASENAME }}
+          path: |
+            data/output/*.srt
+            data/output/*.txt
+            data/output/*_summary.md
+
+      - name: Commit outputs back to repo
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: add outputs for ${{ vars.OUTPUT_BASENAME }}"
+          file_pattern: data/output/*.srt data/output/*.txt data/output/*_summary.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+.venv/
+
+data/input/
+data/intermediate/
+data/output/*.wav
+
+.DS_Store
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: setup run
+setup:
+	pip install -r requirements.txt
+
+run:
+	python -m src.are_summarizer.cli --config config/settings.example.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# ARE Summarizer
+
+Podcast audio summarization pipeline for "セキュリティのアレ".
+
+## Usage
+
+```sh
+make setup
+make run
+```
+
+See `config/settings.example.yaml` for configuration template.

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -1,0 +1,13 @@
+episode:
+  audio_url: "https://example.com/path/to/audio.mp3"
+  title: "セキュリティのアレ #YYYYMMDD"
+  date: "2025-08-25"
+output:
+  dir: "data/output"
+  basename: "are_20250825"
+transcribe:
+  model_size: "base"
+  language: "ja"
+  beam_size: 5
+  vad_frame_ms: 30
+  vad_aggressiveness: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+faster-whisper==1.0.0
+webrtcvad==2.0.10
+numpy>=1.26
+soundfile>=0.12
+librosa>=0.10
+pydub>=0.25
+pandas>=2.2
+pyyaml>=6.0
+tqdm>=4.66

--- a/scripts/dev_install.ps1
+++ b/scripts/dev_install.ps1
@@ -1,0 +1,1 @@
+pip install -r requirements.txt

--- a/scripts/install_ffmpeg_ubuntu.sh
+++ b/scripts/install_ffmpeg_ubuntu.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+sudo apt-get update
+sudo apt-get install -y ffmpeg

--- a/src/are_summarizer/cli.py
+++ b/src/are_summarizer/cli.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import yaml
+
+from .fetch import download_audio
+from .vad import apply_vad_and_save_wav
+from .transcribe import transcribe_whisper
+from .summarize import naive_summarize
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config/settings.example.yaml")
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    outdir = cfg["output"]["dir"]
+    os.makedirs(outdir, exist_ok=True)
+    base = cfg["output"]["basename"]
+
+    # 1) ダウンロード
+    audio_path = os.path.join("data", "input", f"{base}.mp3")
+    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
+    download_audio(cfg["episode"]["audio_url"], audio_path)
+
+    # 2) VAD
+    wav_path = os.path.join("data", "intermediate", f"{base}_vad.wav")
+    os.makedirs(os.path.dirname(wav_path), exist_ok=True)
+    apply_vad_and_save_wav(
+        audio_path,
+        wav_path,
+        frame_ms=cfg["transcribe"]["vad_frame_ms"],
+        aggressiveness=cfg["transcribe"]["vad_aggressiveness"],
+    )
+
+    # 3) 文字起こし
+    srt_path = os.path.join(outdir, f"{base}.srt")
+    txt_path = os.path.join(outdir, f"{base}.txt")
+    transcribe_whisper(
+        wav_path,
+        srt_out=srt_path,
+        txt_out=txt_path,
+        model_size=cfg["transcribe"]["model_size"],
+        language=cfg["transcribe"]["language"],
+        beam_size=cfg["transcribe"]["beam_size"],
+    )
+
+    # 4) 要約
+    summary_md = os.path.join(outdir, f"{base}_summary.md")
+    naive_summarize(
+        txt_path,
+        summary_md,
+        title=cfg["episode"]["title"],
+        date=cfg["episode"]["date"],
+    )
+
+    print("DONE:", {"srt": srt_path, "txt": txt_path, "summary": summary_md})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/are_summarizer/fetch.py
+++ b/src/are_summarizer/fetch.py
@@ -1,0 +1,8 @@
+import pathlib
+import urllib.request
+
+
+def download_audio(url: str, dst: str):
+    pathlib.Path(dst).parent.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(url, dst)
+    return dst

--- a/src/are_summarizer/summarize.py
+++ b/src/are_summarizer/summarize.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+def naive_summarize(txt_path: str, out_md: str, title: str, date: str):
+    text = Path(txt_path).read_text(encoding="utf-8")
+    lines = [x.strip() for x in text.splitlines() if x.strip()]
+    head = lines[:20]
+    bullets = "\n".join([f"- {l[:120]}" for l in head])
+
+    md = f"""# {title}
+- 収録日: {date}
+
+## 概要（暫定）
+{bullets}
+
+## 今後の予定
+- 話者分離（埋め込み＋クラスタリング）導入
+- セクションごとの要旨生成
+- タイムスタンプ目次の自動生成
+"""
+    Path(out_md).write_text(md, encoding="utf-8")

--- a/src/are_summarizer/transcribe.py
+++ b/src/are_summarizer/transcribe.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from faster_whisper import WhisperModel
+
+
+def transcribe_whisper(
+    wav_path,
+    srt_out,
+    txt_out,
+    model_size="base",
+    language="ja",
+    beam_size=5,
+):
+    model = WhisperModel(model_size, device="cpu", compute_type="int8")
+    segments, _ = model.transcribe(wav_path, language=language, beam_size=beam_size)
+
+    with open(txt_out, "w", encoding="utf-8") as f:
+        for seg in segments:
+            f.write(seg.text.strip() + "\n")
+
+    def srt_time(t):
+        from math import floor
+
+        h = floor(t / 3600)
+        m = floor((t % 3600) / 60)
+        s = floor(t % 60)
+        ms = int((t - floor(t)) * 1000)
+        return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+    segments, _ = model.transcribe(wav_path, language=language, beam_size=beam_size)
+    with open(srt_out, "w", encoding="utf-8") as f:
+        idx = 1
+        for seg in segments:
+            f.write(f"{idx}\n")
+            f.write(f"{srt_time(seg.start)} --> {srt_time(seg.end)}\n")
+            f.write(seg.text.strip() + "\n\n")
+            idx += 1

--- a/src/are_summarizer/vad.py
+++ b/src/are_summarizer/vad.py
@@ -1,0 +1,36 @@
+import numpy as np
+import soundfile as sf
+import webrtcvad
+from pydub import AudioSegment
+
+
+def _to_wav_mono16k(src_path: str) -> AudioSegment:
+    seg = AudioSegment.from_file(src_path)
+    seg = seg.set_channels(1).set_frame_rate(16000).set_sample_width(2)
+    return seg
+
+
+def apply_vad_and_save_wav(
+    src_audio: str, dst_wav: str, frame_ms: int = 30, aggressiveness: int = 2
+):
+    seg = _to_wav_mono16k(src_audio)
+    samples = np.array(seg.get_array_of_samples())
+    vad = webrtcvad.Vad(aggressiveness)
+    frame_len = int(16000 * frame_ms / 1000)
+    voiced = []
+
+    for i in range(0, len(samples), frame_len):
+        frame = samples[i : i + frame_len]
+        if len(frame) < frame_len:
+            break
+        ok = vad.is_speech(frame.tobytes(), sample_rate=16000)
+        if ok:
+            voiced.append(frame)
+
+    if voiced:
+        out = np.concatenate(voiced).astype(np.int16)
+    else:
+        out = np.zeros(16000, dtype=np.int16)
+
+    sf.write(dst_wav, out, 16000)
+    return dst_wav


### PR DESCRIPTION
## Summary
- add requirements and config template
- implement pipeline modules for download, VAD, transcription, and summary
- add GitHub Actions for weekly scheduled and manual runs

## Testing
- `python -m py_compile $(find src -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b2be1324ec8333a27856b76eb92c64